### PR TITLE
fix deep object comparison

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,9 @@ function eql(matcher, val){
       // we match all values of `matcher` in `val`
       for (var i in matcher) {
         if (matcher.hasOwnProperty(i)) {
-          if (!eql(matcher[i], val[i])) return false;
+          if (!val.hasOwnProperty(i) || !eql(matcher[i], val[i])) {
+            return false;
+          }
         }
         keys[i] = true;
       }


### PR DESCRIPTION
This fixes the following issue:

```
var a = { _id: { bytes: new Buffer(…) }}; // { _id: ObjectId }
var b = { bytes: new Buffer(…); }; // ObjectId
eql(a, b);
```

This piece of code throws [TypeError: Cannot read property 'bytes' of
undefined] because it does not check whether `b` has a higher-level
property (`_id`) before diving deeper into the matcher object (`a`).
