### PR TITLE
fix object to null comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+npm-debug.log

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function eql(matcher, val){
       // we match all values of `matcher` in `val`
       for (var i in matcher) {
         if (matcher.hasOwnProperty(i)) {
-          if (!val.hasOwnProperty(i) || !eql(matcher[i], val[i])) {
+          if (!val || !val.hasOwnProperty(i) || !eql(matcher[i], val[i])) {
             return false;
           }
         }

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
   "dependencies": {
     "debug": "*",
     "component-type": "1.1.0"
+  },
+  "scripts": {
+    "test": "node test"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,4 @@
+var assert = require('assert');
+var eql = require('./index');
+
+assert(eql({ 'a': 'b' }, null) === false);


### PR DESCRIPTION
Comparing an object with at least one key against `null` resulted in

```
TypeError: Cannot call method 'hasOwnProperty' of null
    at eql (/code/lib/mongo-eql/index.js:56:20)
    ...
```

Test included.
